### PR TITLE
[feat] Add dark/light mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>LilArt.Studios</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
-    <link rel="stylesheet" href="styleLilArt.css">
+    <link rel="stylesheet" href="public/styles/main.css">
     <link
         href="https://fonts.googleapis.com/css2?family=Libertinus+Mono&family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=UoqMunThenKhung&display=swap"
         rel="stylesheet">
@@ -73,6 +73,9 @@
                                 </li>
                             </ul>
 
+                        </li>
+                        <li class="nav-item">
+                            <button id="theme-toggle" class="btn btn-outline-secondary ms-lg-3" aria-label="Cambiar tema">🌙</button>
                         </li>
                     </ul>
                 </div>
@@ -406,6 +409,7 @@
     <script src="./javascript/reservarCitasWhatsapp.js"></script>
     <script src="./javascript/navBar.js"></script>
     <script src="./javascript/phoneOnlyNumber.js"></script>
+    <script type="module" src="./src/ui/main.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q"
         crossorigin="anonymous"></script>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -2,11 +2,22 @@ body {
   margin: 0;
   font-family: 'Arial', sans-serif;
   padding: 0;
-  background-image: url('images.img/fondo/esmalte-marron-gris.png');
-  background-size: cover;
-  background-position: center;
-  backdrop-filter: blur(6px);
-  background-repeat: no-repeat;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+body.light-mode {
+  --background-color: #ffffff;
+  --text-color: #501d06;
+  --hover-color: #a85b3b;
+  --footer-border-color: rgba(80, 29, 6, 0.2);
+}
+
+body.dark-mode {
+  --background-color: #212529;
+  --text-color: #f8f9fa;
+  --hover-color: #a85b3b;
+  --footer-border-color: rgba(248, 249, 250, 0.2);
 }
 
 header {
@@ -19,7 +30,7 @@ header {
 h2 {
   font-family: "Libertinus Mono", monospace;
   font-style: normal;
-  color: #501d06;
+  color: var(--text-color);
   font-size: 30px;
   font-weight: 500;
 }
@@ -184,18 +195,18 @@ margin-bottom: 20px;
 
 .my-footer {
   backdrop-filter: blur(5px);
-  border-top: 1px solid rgba(80, 29, 6, 0.2); 
-  color: #501d06;
+  border-top: 1px solid var(--footer-border-color);
+  color: var(--text-color);
   font-size: 16px;
 }
 
 .footer-link {
-  color: #501d06;
+  color: var(--text-color);
   text-decoration: none;
 }
 
 .footer-link:hover {
-  color: #a85b3b;
+  color: var(--hover-color);
 }
 
 .accordion-item {
@@ -206,11 +217,11 @@ margin-bottom: 20px;
 
 .accordion-button {
   background-color: transparent;
-  color: #501d06;
+  color: var(--text-color);
   font-weight: bold;
 }
 
 .accordion-button:not(.collapsed) {
-  background-color: rgba(255, 255, 255, 0.25); /* cuando está abierto */
-  color: #501d06;
+  background-color: rgba(255, 255, 255, 0.25); /* when open */
+  color: var(--text-color);
 }

--- a/src/ui/main.js
+++ b/src/ui/main.js
@@ -1,0 +1,1 @@
+import './themeToggle.js';

--- a/src/ui/themeToggle.js
+++ b/src/ui/themeToggle.js
@@ -1,0 +1,17 @@
+// Handles theme toggling between light and dark modes.
+const themeToggleButton = document.getElementById('theme-toggle');
+
+const applyTheme = (theme) => {
+  document.body.classList.remove('light-mode', 'dark-mode');
+  document.body.classList.add(`${theme}-mode`);
+  themeToggleButton.textContent = theme === 'dark' ? '☀️' : '🌙';
+};
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+applyTheme(savedTheme);
+
+themeToggleButton.addEventListener('click', () => {
+  const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+  applyTheme(newTheme);
+  localStorage.setItem('theme', newTheme);
+});


### PR DESCRIPTION
## Summary
- add light and dark theme styles and remove background image
- create theme toggle module and import from main entry point
- add toggle button in navigation and preserve mode with localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e88523908330b792791d9b86a518